### PR TITLE
Some sample emails which inconveniently leave off anglebrackets

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -40,7 +40,7 @@ class EmailMessage(object):
     QUOTE_HDR_REGEX = r'^:etorw.*nO'
     MULTI_QUOTE_HDR_REGEX = r'(On\s.*?wrote:)'
     QUOTED_REGEX = r'(>+)'
-    FROM_SUBJ_TO_DATE = r'^(?:From|Subject|To|Date):\s'
+    FROM_SUBJ_TO_DATE = r'^\s*(?:From|Subject|Sent|To|Date):\s'
 
     def __init__(self, text):
         self.fragments = []

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -41,6 +41,7 @@ class EmailMessage(object):
     MULTI_QUOTE_HDR_REGEX = r'(On\s.*?wrote:)'
     QUOTED_REGEX = r'(>+)'
     FROM_SUBJ_TO_DATE = r'^\s*(?:From|Subject|Sent|To|Date):\s'
+    INLINE_WROTE = r'.+\s+<\S+@\S+>\s+wrote:$'
 
     def __init__(self, text):
         self.fragments = []
@@ -66,9 +67,10 @@ class EmailMessage(object):
 
         self.lines = self.text.split('\n')
         for i in range(len(self.lines)-3):
-            if re.match(self.FROM_SUBJ_TO_DATE, self.lines[i]) and \
-               re.match(self.FROM_SUBJ_TO_DATE, self.lines[i+1]) and \
-               re.match(self.FROM_SUBJ_TO_DATE, self.lines[i+2]):
+            if re.match(self.INLINE_WROTE, self.lines[i]) or \
+               (re.match(self.FROM_SUBJ_TO_DATE, self.lines[i]) and \
+                re.match(self.FROM_SUBJ_TO_DATE, self.lines[i+1]) and \
+                re.match(self.FROM_SUBJ_TO_DATE, self.lines[i+2])):
                   self.lines = self.lines[:i] + ['> ' + l for l in self.lines[i:]]
                   break
 

--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -40,6 +40,7 @@ class EmailMessage(object):
     QUOTE_HDR_REGEX = r'^:etorw.*nO'
     MULTI_QUOTE_HDR_REGEX = r'(On\s.*?wrote:)'
     QUOTED_REGEX = r'(>+)'
+    FROM_SUBJ_TO_DATE = r'^(?:From|Subject|To|Date):\s'
 
     def __init__(self, text):
         self.fragments = []
@@ -64,8 +65,14 @@ class EmailMessage(object):
                 self.text)
 
         self.lines = self.text.split('\n')
-        self.lines.reverse()
+        for i in range(len(self.lines)-3):
+            if re.match(self.FROM_SUBJ_TO_DATE, self.lines[i]) and \
+               re.match(self.FROM_SUBJ_TO_DATE, self.lines[i+1]) and \
+               re.match(self.FROM_SUBJ_TO_DATE, self.lines[i+2]):
+                  self.lines = self.lines[:i] + ['> ' + l for l in self.lines[i:]]
+                  break
 
+        self.lines.reverse()
         for line in self.lines:
             self._scan_line(line)
 

--- a/test/emails/email_anglebrackets_stripped.txt
+++ b/test/emails/email_anglebrackets_stripped.txt
@@ -1,0 +1,20 @@
+Hi Christine,
+ 
+Im just wondering are you still looking to go to clonmel ?
+ 
+Regards,
+Darryl
+ 
+From: christine.rolemey_re@msg.example.com
+Subject: Re:
+To: Darrylppp@live.ie
+Date: Mon, 25 Nov 2013 16:33:36 -0800
+
+Ya that would be perfect just drop me a mail 
+On 26 Nov 2013 00:25, "Darrylppp" <darylp@msg.example.com> wrote:
+
+
+
+Oh thats cool because i travel with a girl every second week to a lab in there. 
+We can meet up thursday next week if you like as i have exams till then 
+Sent from Samsung Mobile

--- a/test/emails/email_anglebrackets_stripped_2.txt
+++ b/test/emails/email_anglebrackets_stripped_2.txt
@@ -1,0 +1,12 @@
+HI Mary,
+Thanks for that.
+________________________________
+ From: Mary <mary_re7493@msg.example.com>
+To: luisa_example_email@yahoo.ie
+Sent: Thursday, 1 January 1970, 0:00:00
+Subject: Re: Fw: New Carsharing Contact - Mary
+
+
+Hi Luisa,
+
+Thanks for your reply. My son ...

--- a/test/emails/email_inline_wrote.txt
+++ b/test/emails/email_inline_wrote.txt
@@ -1,0 +1,31 @@
+Hi Molly,
+
+I think it should be workable alright.
+
+Feel free 2 give me a call at any time that suits on 086 1234567.
+
+Adrian
+
+molly <molly_re5041@msg.example.com> wrote:
+
+Hi Adrian,
+
+thanks for the reply
+
+text snipped
+
+Best wishes,
+Molly
+
+
+On 19 July 2013 08:35, Adrian <adrian_5041@msg.example.com> wrote:
+
+> Hi Molly,
+>
+> Yep, I would still be interested ...
+> text snipped
+>
+> Regards,
+>
+> Adrian
+>

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -97,6 +97,10 @@ class EmailMessageTest(unittest.TestCase):
         with open('test/emails/email_anglebrackets_stripped.txt') as email:
             self.assertTrue("christine.rolemey_re@msg.example.com" not in EmailReplyParser.parse_reply(email.read()))
 
+    def test_anglebrackets_stripped_2(self):
+        with open('test/emails/email_anglebrackets_stripped_2.txt') as email:
+            self.assertTrue("Hi Luisa" not in EmailReplyParser.parse_reply(email.read()))
+
     def get_email(self, name):
         """ Return EmailMessage instance
         """

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -101,6 +101,10 @@ class EmailMessageTest(unittest.TestCase):
         with open('test/emails/email_anglebrackets_stripped_2.txt') as email:
             self.assertTrue("Hi Luisa" not in EmailReplyParser.parse_reply(email.read()))
 
+    def test_inline_wrote(self):
+        with open('test/emails/email_inline_wrote.txt') as email:
+            self.assertTrue("Hi Adrian," not in EmailReplyParser.parse_reply(email.read()))
+
     def get_email(self, name):
         """ Return EmailMessage instance
         """

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -93,6 +93,10 @@ class EmailMessageTest(unittest.TestCase):
         with open('test/emails/email_one_is_not_on.txt') as email:
             self.assertTrue("On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:" not in EmailReplyParser.parse_reply(email.read()))
 
+    def test_anglebrackets_stripped(self):
+        with open('test/emails/email_anglebrackets_stripped.txt') as email:
+            self.assertTrue("christine.rolemey_re@msg.example.com" not in EmailReplyParser.parse_reply(email.read()))
+
     def get_email(self, name):
         """ Return EmailMessage instance
         """


### PR DESCRIPTION
I extracted these sample emails from a corpus of email exchanges.

I'm not sure if this is a direction you want to go with email-reply-parser (the only danger I could see would be if INLINE_WROTE matched falsely: https://github.com/eoghanmurray/email-reply-parser/commit/64754e2e71fcbae0aba24dbfb7d2531f6c9eb32f), but this sort of thing definitely exists 'in the wild'!

Eoghan
