### PR TITLE
Fixes reply line started with 'On'

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -38,7 +38,7 @@ class EmailMessage(object):
 
     SIG_REGEX = r'(--|__|-\w)|(^Sent from my (\w+\s*){1,3})'
     QUOTE_HDR_REGEX = r'^:etorw.*nO'
-    MULTI_QUOTE_HDR_REGEX = r'(On\s.*?wrote:)'
+    MULTI_QUOTE_HDR_REGEX = r'(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)'
     QUOTED_REGEX = r'(>+)'
 
     def __init__(self, text):

--- a/test/emails/email_partial_quote_header.txt
+++ b/test/emails/email_partial_quote_header.txt
@@ -1,0 +1,13 @@
+On your remote host you can run:
+
+     telnet 127.0.0.1 52698
+
+This should connect to TextMate (on your Mac, via the tunnel). If that 
+fails, the tunnel is not working.
+
+On 9 Jan 2014, at 2:47, George Plymale wrote:
+
+> I am having an odd issue wherein suddenly port forwarding stopped 
+> working in a particular scenario for me.  By default I have ssh set to 
+> use the following config (my ~/.ssh/config file):
+> […]

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -109,6 +109,12 @@ class EmailMessageTest(unittest.TestCase):
         with open('test/emails/email_one_is_not_on.txt') as email:
             self.assertTrue("On Oct 1, 2012, at 11:55 PM, Dave Tapley wrote:" not in EmailReplyParser.parse_reply(email.read()))
 
+    def test_partial_quote_header(self):
+        message = self.get_email('email_partial_quote_header')
+        self.assertTrue("On your remote host you can run:" in message.reply)
+        self.assertTrue("telnet 127.0.0.1 52698" in message.reply)
+        self.assertTrue("This should connect to TextMate" in message.reply)
+
     def get_email(self, name):
         """ Return EmailMessage instance
         """


### PR DESCRIPTION
Added test and new regex fixing issue for a reply line starting with 'On'. The regex was so greedy it would continue down to the next instance of 'wrote:'. 

Matches up with a recent submission to the Github email_reply_parser: https://github.com/danielchatfield/email_reply_parser/commit/c7678f09848ef334cc352c5b875371f844927910

From that patch: "This is the fix to #23. It uses the negative lookahead assertion to prevent matches where On appears twice. The whitespace matcher after the second on is required to make sure that people with names beginning with 'On' don't trigger it."
