### PR TITLE
Parse email header lines without a delimiter (fixes #1)

### DIFF
--- a/email_reply_parser/__init__.py
+++ b/email_reply_parser/__init__.py
@@ -40,6 +40,7 @@ class EmailMessage(object):
     QUOTE_HDR_REGEX = r'^:etorw.*nO'
     MULTI_QUOTE_HDR_REGEX = r'(?!On.*On\s.+?wrote:)(On\s(.+?)wrote:)'
     QUOTED_REGEX = r'(>+)'
+    HEADER_REGEX = r'^(From|Sent|To|Subject): .+'
 
     def __init__(self, text):
         self.fragments = []
@@ -91,25 +92,21 @@ class EmailMessage(object):
             line - a row of text from an email message
         """
 
-        line.strip('\n')
-
-        if re.match(self.SIG_REGEX, line):
-            line.lstrip()
-
-        is_quoted = re.match(self.QUOTED_REGEX, line) != None
+        is_quoted = re.match(self.QUOTED_REGEX, line) is not None
+        is_header = re.match(self.HEADER_REGEX, line) is not None
 
         if self.fragment and len(line.strip()) == 0:
             if re.match(self.SIG_REGEX, self.fragment.lines[-1]):
                 self.fragment.signature = True
                 self._finish_fragment()
 
-        if self.fragment and ((self.fragment.quoted == is_quoted)
+        if self.fragment and (((self.fragment.headers == is_header) and (self.fragment.quoted == is_quoted))
             or (self.fragment.quoted and (self.quote_header(line) or len(line.strip()) == 0))):
 
             self.fragment.lines.append(line)
         else:
             self._finish_fragment()
-            self.fragment = Fragment(is_quoted, line)
+            self.fragment = Fragment(is_quoted, line, headers=is_header)
 
     def quote_header(self, line):
         """ Determines whether line is part of a quoted area
@@ -126,8 +123,15 @@ class EmailMessage(object):
 
         if self.fragment:
             self.fragment.finish()
+            if self.fragment.headers:
+                # Regardless of what's been seen to this point, if we encounter a headers fragment,
+                # all the previous fragments should be marked hidden and found_visible set to False.
+                self.found_visible = False
+                for f in self.fragments:
+                    f.hidden = True
             if not self.found_visible:
                 if self.fragment.quoted \
+                or self.fragment.headers \
                 or self.fragment.signature \
                 or (len(self.fragment.content.strip()) == 0):
 
@@ -143,8 +147,9 @@ class Fragment(object):
         an Email Message, labeling each part.
     """
 
-    def __init__(self, quoted, first_line):
+    def __init__(self, quoted, first_line, headers=False):
         self.signature = False
+        self.headers = headers
         self.hidden = False
         self.quoted = quoted
         self._content = None

--- a/test/emails/email_headers_no_delimiter.txt
+++ b/test/emails/email_headers_no_delimiter.txt
@@ -1,0 +1,15 @@
+And another reply!
+
+From: Dan Watson [mailto:user@host.com]
+Sent: Monday, November 26, 2012 10:48 AM
+To: Watson, Dan
+Subject: Re: New Issue
+
+A reply
+
+--
+Sent from my iPhone
+
+On Nov 26, 2012, at 10:27 AM, "Watson, Dan" <user@host2.com> wrote:
+This is a message.
+With a second line.

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -115,6 +115,10 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue("telnet 127.0.0.1 52698" in message.reply)
         self.assertTrue("This should connect to TextMate" in message.reply)
 
+    def test_email_headers_no_delimiter(self):
+        message = self.get_email('email_headers_no_delimiter')
+        self.assertEqual(message.reply.strip(), 'And another reply!')
+
     def get_email(self, name):
         """ Return EmailMessage instance
         """


### PR DESCRIPTION
Scan the lines to see if they look like common email headers, and if so, put the headers in their own hidden fragment. Also, a headers fragment should mark any previously found non-hidden fragments as hidden, since the headers indicate essentially an entire quoted email.