### PR TITLE
add test for android gmail inline response

### DIFF
--- a/test/emails/email_android_gmail_inline.txt
+++ b/test/emails/email_android_gmail_inline.txt
@@ -1,0 +1,24 @@
+This is a test
+
+On Sep 21, 2016 3:18 PM, "frugal" <noreply@frugal.com> wrote:
+>
+>
+> Hi Mert,
+> Here are your unread message(s)
+>
+> Client Company - Hidden
+> Project: Sampoerna Dji Sam Soe 234
+> Akeem Olajuwon 08:08 PM, Aug 28
+> Pitchfork occupy vegan pabst hammock. Wayfarers etsy pok pok, kale chips
+brooklyn four dollar toast street art 3 wolf moon.
+> Akeem Olajuwon 08:08 PM, Aug 28
+> Pitchfork occupy vegan pabst hammock. Wayfarers etsy pok pok, kale chips
+brooklyn four dollar toast street art 3 wolf moon.
+> Akeem Olajuwon 08:08 PM, Aug 28
+> Pitchfork occupy vegan pabst hammock. Wayfarers etsy pok pok, kale chips
+brooklyn four dollar toast street art 3 wolf moon.
+> VIEW ALL MESSAGES
+>
+> frugal
+> This is it
+> frugal, Inc. 8 4th, Potter Valley, CA 94025

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -135,6 +135,10 @@ class EmailMessageTest(unittest.TestCase):
         with open('test/emails/email_2_2.txt') as f:
             self.assertEqual("Outlook with a reply directly above line", EmailReplyParser.parse_reply(f.read()))
 
+    def test_parse_android_gmail_inline(self):
+        with open('test/emails/email_android_gmail_inline.txt') as f:
+            self.assertEqual("This is a test", EmailReplyParser.parse_reply(f.read()))
+
     def test_sent_from_iphone(self):
         with open('test/emails/email_iPhone.txt') as email:
             self.assertTrue("Sent from my iPhone" not in EmailReplyParser.parse_reply(email.read()))


### PR DESCRIPTION
This adds an example of an inline response sent from android gmail. This test currently fails.  

I'd be happy to help work on a fix.
