### PR TITLE
feat: Support Python 3.5, 3.6, 3.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
   - "pypy"
 script: python setup.py test
 deploy:
@@ -15,3 +16,10 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: zapier/email-reply-parser
+
+matrix:
+  include:
+    - python: 2.6
+      dist: trusty
+    - python: 3.3
+      dist: trusty

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ]
 )


### PR DESCRIPTION
Update trove classifiers and travis config to support Python 3.5, 3.6 and 3.7. Looks like CI passes so this should be good to go.

Also fix 2.6 and 3.3 builds as per https://github.com/travis-ci/travis-ci/issues/9133